### PR TITLE
imp: better performance for /hierarchy.php

### DIFF
--- a/lib-sql/indices.sql
+++ b/lib-sql/indices.sql
@@ -29,6 +29,12 @@ CREATE INDEX IF NOT EXISTS idx_osmline_parent_osm_id
 CREATE INDEX IF NOT EXISTS idx_postcode_postcode
   ON location_postcode USING BTREE (postcode) {{db.tablespace.search_index}};
 
+CREATE INDEX {{sql.if_index_not_exists}} idx_placex_relation_hierarchy
+  ON placex (class, type, osm_type, country_code)
+  WHERE class = 'boundary'
+    AND type = 'administrative'
+    AND osm_type = 'R';
+
 -- Indices only needed for updating.
 
 {% if not drop %}


### PR DESCRIPTION
Statt viele SQL-Abfragen rekursiv aufzurufen, wird hiermit nur eine SQL-Abfrage für alle Kinder gemacht und dann das Ergebnis rekursiv in PHP in eine Baumstruktur geändert.